### PR TITLE
Fix request forgery vulnerability in PayPal verification

### DIFF
--- a/backend/utils/paypal.js
+++ b/backend/utils/paypal.js
@@ -43,17 +43,21 @@ export async function checkIfNewTransaction(orderModel, paypalTransactionId) {
   }
 }
 
-export async function verifyPayPalPayment(paypalTransactionId) {
-  const accessToken = await getPayPalAccessToken();
-  const paypalResponse = await fetch(
-    `${PAYPAL_API_URL}/v2/checkout/orders/${paypalTransactionId}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
+// Validate the transaction ID format (e.g., using regex)
+if (!/^[a-zA-Z0-9_-]+$/.test(paypalTransactionId)) {
+  throw new Error('Invalid PayPal transaction ID');
+}
+
+const paypalResponse = await fetch(
+  `${PAYPAL_API_URL}/v2/checkout/orders/${paypalTransactionId}`,
+  {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  }
+);
+
   if (!paypalResponse.ok) throw new Error('Failed to verify payment');
 
   const paypalData = await paypalResponse.json();


### PR DESCRIPTION
Problem
Using user input directly in constructing URLs for outgoing HTTP requests can lead to request forgery attacks, such as SSRF (Server-Side Request Forgery). Attackers can manipulate these inputs to perform unintended actions or access restricted areas.

Solution
Avoid Direct User Input in URLs: Do not use raw user inputs to construct URLs, especially for the hostname and path. Instead, validate and sanitize inputs, or use them to select from a predefined set of allowed values.